### PR TITLE
Ignore binary artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,16 @@ gradle/wrapper/gradle-wrapper.jar
 local.properties
 *.log
 /build
+
+# Ignore binary files
+*.class
+*.jar
+*.apk
+*.exe
+*.dll
+*.so
+*.dylib
+*.bin
+*.o
+*.a
+*.lib


### PR DESCRIPTION
## Summary
- ignore common binary output files in .gitignore to prevent committing build artifacts

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68955814756c832c8af8bedce7f6ccae