### PR TITLE
Fix AndroidManifest structure and exported flag

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,11 +12,12 @@
         <activity android:name=".SettingsActivity"/>
         <activity android:name=".StatsActivity"/>
         <activity android:name=".GameBoardActivity"/>
-        <activity android:name=".MainActivity">
         <activity android:name=".VisualBoardActivity"/>
         <activity android:name=".PropertyListActivity"/>
         <activity android:name=".MainActivity"/>
-        <activity android:name=".MainMenuActivity">
+        <activity
+            android:name=".MainMenuActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>


### PR DESCRIPTION
## Summary
- correct activity declarations and remove duplicates in AndroidManifest
- mark MainMenuActivity as exported for launcher intent

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68955ac737f8832cbee78a33368ba02e