### PR TITLE
Specify Kotlin JVM target to avoid JDK 21 error

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,6 +27,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
+    }
 }
 
 dependencies {


### PR DESCRIPTION
## Summary
- force Kotlin to compile with Java 8 bytecode to avoid "Unknown Kotlin JVM target: 21" error

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895642865a0832cb4cf857d7e749da7