### PR TITLE
Add Room database and DAO for Player

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
-    id 'kotlin-kapt'
 }
 
 android {
@@ -39,5 +38,5 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-viewmodel:2.6.2'
     implementation 'androidx.lifecycle:lifecycle-livedata:2.6.2'
     implementation 'androidx.room:room-runtime:2.6.1'
-    kapt 'androidx.room:room-compiler:2.6.1'
+    annotationProcessor 'androidx.room:room-compiler:2.6.1'
 }

--- a/app/src/main/java/com/example/monopoly/MonopolyDatabase.java
+++ b/app/src/main/java/com/example/monopoly/MonopolyDatabase.java
@@ -1,0 +1,9 @@
+package com.example.monopoly;
+
+import androidx.room.Database;
+import androidx.room.RoomDatabase;
+
+@Database(entities = {Player.class}, version = 1)
+public abstract class MonopolyDatabase extends RoomDatabase {
+    public abstract PlayerDao playerDao();
+}

--- a/app/src/main/java/com/example/monopoly/PlayerDao.java
+++ b/app/src/main/java/com/example/monopoly/PlayerDao.java
@@ -1,0 +1,27 @@
+package com.example.monopoly;
+
+import androidx.room.Dao;
+import androidx.room.Delete;
+import androidx.room.Insert;
+import androidx.room.Query;
+import androidx.room.Update;
+
+import java.util.List;
+
+@Dao
+public interface PlayerDao {
+    @Insert
+    long insertPlayer(Player player);
+
+    @Update
+    void updatePlayer(Player player);
+
+    @Delete
+    void deletePlayer(Player player);
+
+    @Query("SELECT * FROM Player WHERE id = :id")
+    Player getPlayerById(int id);
+
+    @Query("SELECT * FROM Player")
+    List<Player> getAllPlayers();
+}


### PR DESCRIPTION
## Summary
- add PlayerDao for player CRUD operations
- implement Room MonopolyDatabase to expose the DAO
- configure Room annotation processing in the Gradle build

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68958e6a79b4832ca5128b6b1844d274