### PR TITLE
Handle missing owners in rent processing

### DIFF
--- a/app/src/main/java/com/example/monopoly/GameViewModel.java
+++ b/app/src/main/java/com/example/monopoly/GameViewModel.java
@@ -1,5 +1,7 @@
 package com.example.monopoly;
 
+import android.util.Log;
+
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 
@@ -40,16 +42,30 @@ public class GameViewModel extends ViewModel {
 
     public void processTile(Player player, Tile tile) {
         if (tile.type == TileType.PROPERTY && tile.isOwned && tile.ownerId != player.id) {
-            int rent = 10 + 5 * tile.houseCount;
-            player.money -= rent;
-            for (Player p : players.getValue()) {
+            List<Player> currentPlayers = players.getValue();
+            if (currentPlayers == null) {
+                return;
+            }
+
+            Player owner = null;
+            for (Player p : currentPlayers) {
                 if (p.id == tile.ownerId) {
-                    p.money += rent;
+                    owner = p;
                     break;
                 }
             }
-            // Trigger observers
-            players.setValue(players.getValue());
+
+            if (owner == null) {
+                Log.w("GameViewModel", "Owned tile has no corresponding player: " + tile.name);
+                return;
+            }
+
+            int rent = 10 + 5 * tile.houseCount;
+            player.money -= rent;
+            owner.money += rent;
+
+            // Trigger observers only after successful transaction
+            players.setValue(currentPlayers);
         }
     }
 


### PR DESCRIPTION
## Summary
- Avoid null pointer by checking the players list before iterating
- Skip or warn when an owned tile lacks a valid owner
- Only emit LiveData after a successful rent transfer

## Testing
- `./gradlew test` *(fails: No such file or directory)*
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895b68717b4832c8f547537bc0dcab0