### PR TITLE
Add dice rolling and board update mechanics

### DIFF
--- a/app/src/main/java/com/example/monopoly/GameViewModel.java
+++ b/app/src/main/java/com/example/monopoly/GameViewModel.java
@@ -38,6 +38,37 @@ public class GameViewModel extends ViewModel {
         return tileMap;
     }
 
+    /**
+     * Roll two six-sided dice.
+     *
+     * @return array containing die1, die2 and their total.
+     */
+    public int[] rollDice() {
+        int die1 = 1 + (int) (Math.random() * 6);
+        int die2 = 1 + (int) (Math.random() * 6);
+        return new int[] { die1, die2, die1 + die2 };
+    }
+
+    /**
+     * Move the given player forward by the supplied roll amount.
+     * Wraps around the board and awards $200 for passing GO.
+     */
+    public void movePlayer(Player player, int rollTotal) {
+        int oldPos = player.position;
+        int newPos = (oldPos + rollTotal) % 40;
+        if (oldPos + rollTotal >= 40) {
+            player.money += 200;
+        }
+        player.position = newPos;
+
+        Tile tile = tileMap.get(newPos);
+        if (tile != null) {
+            processTile(player, tile);
+        }
+        // ensure observers are notified of position change even if nothing else happens
+        players.setValue(players.getValue());
+    }
+
     public void processTile(Player player, Tile tile) {
         if (tile.type == TileType.PROPERTY && tile.isOwned && tile.ownerId != player.id) {
             List<Player> currentPlayers = players.getValue();

--- a/app/src/main/java/com/example/monopoly/StatsActivity.java
+++ b/app/src/main/java/com/example/monopoly/StatsActivity.java
@@ -2,20 +2,34 @@ package com.example.monopoly;
 
 import android.os.Bundle;
 import android.widget.TextView;
+
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.ViewModelProvider;
 
+import java.util.List;
+
 public class StatsActivity extends AppCompatActivity {
+    private GameViewModel viewModel;
+    private TextView statsText;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_stats);
 
-        GameViewModel viewModel = new ViewModelProvider(this).get(GameViewModel.class);
-        TextView statsText = findViewById(R.id.stats_text);
+        viewModel = new ViewModelProvider(this).get(GameViewModel.class);
+        statsText = findViewById(R.id.stats_text);
 
+        updateStats(viewModel.players.getValue());
+        viewModel.players.observe(this, this::updateStats);
+    }
+
+    private void updateStats(List<Player> players) {
+        if (players == null) {
+            return;
+        }
         StringBuilder sb = new StringBuilder();
-        for (Player p : viewModel.players.getValue()) {
+        for (Player p : players) {
             sb.append(p.name).append(" at tile ").append(p.position).append("\n");
         }
         statsText.setText(sb.toString());

--- a/app/src/main/java/com/example/monopoly/VisualBoardActivity.java
+++ b/app/src/main/java/com/example/monopoly/VisualBoardActivity.java
@@ -1,14 +1,20 @@
 package com.example.monopoly;
 
 import android.os.Bundle;
-import android.view.ViewGroup;
+import android.widget.GridLayout;
 import android.widget.ImageView;
+
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.ViewModelProvider;
+
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class VisualBoardActivity extends AppCompatActivity {
     private GameViewModel viewModel;
+    private GridLayout grid;
+    private final Map<Integer, ImageView> playerTokens = new HashMap<>();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -16,7 +22,7 @@ public class VisualBoardActivity extends AppCompatActivity {
         setContentView(R.layout.activity_visual_board);
 
         viewModel = new ViewModelProvider(this).get(GameViewModel.class);
-        ViewGroup grid = findViewById(R.id.visual_board);
+        grid = findViewById(R.id.visual_board);
 
         Map<Integer, Tile> tiles = viewModel.getTileMap();
         for (int i = 0; i < 40; i++) {
@@ -29,7 +35,40 @@ public class VisualBoardActivity extends AppCompatActivity {
             } else {
                 tileView.setImageResource(R.drawable.tile_property);
             }
+            GridLayout.LayoutParams params = new GridLayout.LayoutParams();
+            params.rowSpec = GridLayout.spec(i / 10);
+            params.columnSpec = GridLayout.spec(i % 10);
+            tileView.setLayoutParams(params);
             grid.addView(tileView);
         }
+
+        addPlayerTokens(viewModel.players.getValue());
+        viewModel.players.observe(this, this::addPlayerTokens);
+    }
+
+    private void addPlayerTokens(List<Player> players) {
+        if (players == null) {
+            return;
+        }
+        for (Player p : players) {
+            ImageView token = playerTokens.get(p.id);
+            if (token == null) {
+                token = new ImageView(this);
+                token.setImageResource(R.drawable.icon_player);
+                grid.addView(token);
+                playerTokens.put(p.id, token);
+            }
+            moveToken(token, p.position);
+        }
+    }
+
+    private void moveToken(ImageView token, int position) {
+        GridLayout.LayoutParams params = (GridLayout.LayoutParams) token.getLayoutParams();
+        if (params == null) {
+            params = new GridLayout.LayoutParams();
+        }
+        params.rowSpec = GridLayout.spec(position / 10);
+        params.columnSpec = GridLayout.spec(position % 10);
+        token.setLayoutParams(params);
     }
 }


### PR DESCRIPTION
## Summary
- Implement dice roll helper and player movement with GO bonus in `GameViewModel`
- Observe player list in `StatsActivity` to auto-refresh positions
- Render and move player tokens on the visual board when positions change

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895f83efbf8832cb4af10758330bc8a