### PR TITLE
feat: add property trading

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         <activity android:name=".StatsActivity"/>
         <activity android:name=".VisualBoardActivity"/>
         <activity android:name=".PropertyListActivity"/>
+        <activity android:name=".TradeActivity"/>
         <activity android:name=".MainActivity"/>
         <activity
             android:name=".MainMenuActivity"

--- a/app/src/main/java/com/example/monopoly/GameViewModel.java
+++ b/app/src/main/java/com/example/monopoly/GameViewModel.java
@@ -441,6 +441,43 @@ public class GameViewModel extends ViewModel {
         }
     }
 
+    /**
+     * Trade a set of properties from one player to another for the specified
+     * cash amount. Validates that the "from" player owns each property and
+     * that the "to" player can afford the cash portion before completing the
+     * trade.
+     */
+    public void trade(Player from, Player to, List<Tile> properties, int cash) {
+        if (from == null || to == null || properties == null) {
+            return;
+        }
+
+        // Ensure the recipient has enough money for the trade
+        if (cash < 0 || to.money < cash) {
+            return;
+        }
+
+        // Ensure all properties are owned by the "from" player
+        for (Tile t : properties) {
+            if (t.ownerId != from.id) {
+                return;
+            }
+        }
+
+        // Transfer cash
+        if (cash > 0) {
+            from.money += cash;
+            to.money -= cash;
+        }
+
+        // Transfer property ownership
+        for (Tile t : properties) {
+            t.ownerId = to.id;
+        }
+
+        players.setValue(players.getValue());
+    }
+
     public void upgradeHouse(int playerId, Tile tile) {
         // Must own the tile and entire color group
         if (tile.ownerId != playerId || !ownsGroup(playerId, tile.colorGroup)) {

--- a/app/src/main/java/com/example/monopoly/MainMenuActivity.java
+++ b/app/src/main/java/com/example/monopoly/MainMenuActivity.java
@@ -26,4 +26,9 @@ public class MainMenuActivity extends AppCompatActivity {
         Intent intent = new Intent(this, VisualBoardActivity.class);
         startActivity(intent);
     }
+
+    public void showTrade(View view) {
+        Intent intent = new Intent(this, TradeActivity.class);
+        startActivity(intent);
+    }
 }

--- a/app/src/main/java/com/example/monopoly/Player.java
+++ b/app/src/main/java/com/example/monopoly/Player.java
@@ -21,4 +21,9 @@ public class Player {
         this.inJail = false;
         this.jailFreeCards = 0;
     }
+
+    @Override
+    public String toString() {
+        return name;
+    }
 }

--- a/app/src/main/java/com/example/monopoly/TradeActivity.java
+++ b/app/src/main/java/com/example/monopoly/TradeActivity.java
@@ -1,0 +1,121 @@
+package com.example.monopoly;
+
+import android.os.Bundle;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.CheckBox;
+import android.widget.EditText;
+import android.widget.LinearLayout;
+import android.widget.Spinner;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.lifecycle.ViewModelProvider;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class TradeActivity extends AppCompatActivity {
+    private GameViewModel viewModel;
+    private Spinner fromSpinner;
+    private Spinner toSpinner;
+    private LinearLayout propertyContainer;
+    private EditText cashInput;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_trade);
+
+        viewModel = new ViewModelProvider(this).get(GameViewModel.class);
+
+        fromSpinner = findViewById(R.id.spinner_from);
+        toSpinner = findViewById(R.id.spinner_to);
+        propertyContainer = findViewById(R.id.property_container);
+        cashInput = findViewById(R.id.cash_input);
+        Button tradeButton = findViewById(R.id.button_trade);
+
+        List<Player> players = viewModel.players.getValue();
+        if (players == null) {
+            players = new ArrayList<>();
+        }
+        ArrayAdapter<Player> adapter = new ArrayAdapter<>(this,
+                android.R.layout.simple_spinner_item, players);
+        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        fromSpinner.setAdapter(adapter);
+        toSpinner.setAdapter(adapter);
+
+        viewModel.players.observe(this, updated -> {
+            adapter.clear();
+            if (updated != null) {
+                adapter.addAll(updated);
+            }
+            adapter.notifyDataSetChanged();
+            refreshProperties(getSelectedFrom());
+        });
+
+        fromSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                refreshProperties(getSelectedFrom());
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) {
+            }
+        });
+
+        tradeButton.setOnClickListener(v -> {
+            Player from = getSelectedFrom();
+            Player to = getSelectedTo();
+            if (from == null || to == null || from.id == to.id) {
+                return;
+            }
+            List<Tile> selected = new ArrayList<>();
+            for (int i = 0; i < propertyContainer.getChildCount(); i++) {
+                View child = propertyContainer.getChildAt(i);
+                if (child instanceof CheckBox) {
+                    CheckBox cb = (CheckBox) child;
+                    if (cb.isChecked()) {
+                        selected.add((Tile) cb.getTag());
+                    }
+                }
+            }
+            int cash = 0;
+            String text = cashInput.getText().toString().trim();
+            if (!text.isEmpty()) {
+                cash = Integer.parseInt(text);
+            }
+            viewModel.trade(from, to, selected, cash);
+            finish();
+        });
+
+        refreshProperties(getSelectedFrom());
+    }
+
+    private Player getSelectedFrom() {
+        return (Player) fromSpinner.getSelectedItem();
+    }
+
+    private Player getSelectedTo() {
+        return (Player) toSpinner.getSelectedItem();
+    }
+
+    private void refreshProperties(Player owner) {
+        propertyContainer.removeAllViews();
+        if (owner == null) {
+            return;
+        }
+        Map<Integer, Tile> tiles = viewModel.getTileMap();
+        for (Tile t : tiles.values()) {
+            if (t.ownerId == owner.id) {
+                CheckBox cb = new CheckBox(this);
+                cb.setText(t.name);
+                cb.setTag(t);
+                propertyContainer.addView(cb);
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_main_menu.xml
+++ b/app/src/main/res/layout/activity_main_menu.xml
@@ -11,4 +11,7 @@
 
     <Button android:text="לוח גרפי" android:onClick="showBoard"
         android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="16dp"/>
+
+    <Button android:text="Trade" android:onClick="showTrade"
+        android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="16dp"/>
 </LinearLayout>

--- a/app/src/main/res/layout/activity_trade.xml
+++ b/app/src/main/res/layout/activity_trade.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <Spinner
+            android:id="@+id/spinner_from"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <Spinner
+            android:id="@+id/spinner_to"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp" />
+
+        <LinearLayout
+            android:id="@+id/property_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:layout_marginTop="16dp" />
+
+        <EditText
+            android:id="@+id/cash_input"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:hint="Cash"
+            android:inputType="number" />
+
+        <Button
+            android:id="@+id/button_trade"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Trade"
+            android:layout_marginTop="16dp" />
+
+    </LinearLayout>
+</ScrollView>


### PR DESCRIPTION
## Summary
- allow players to trade properties and cash via new GameViewModel.trade
- add TradeActivity and layout for selecting players, properties, and cash
- expose trade option from main menu and show player names in spinners

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898eba9d8e4832ca1ad87a0e9016119