### PR TITLE
Implement turn progression in GameViewModel and notify activities

### DIFF
--- a/app/src/main/java/com/example/monopoly/PropertyListActivity.java
+++ b/app/src/main/java/com/example/monopoly/PropertyListActivity.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.ViewModelProvider;
@@ -23,6 +24,12 @@ public class PropertyListActivity extends AppCompatActivity {
         refreshProperties();
 
         viewModel.players.observe(this, players -> refreshProperties());
+
+        viewModel.currentTurn.observe(this, player -> {
+            if (player != null) {
+                Toast.makeText(this, player.name + "'s turn", Toast.LENGTH_SHORT).show();
+            }
+        });
     }
 
     private void refreshProperties() {

--- a/app/src/main/java/com/example/monopoly/StatsActivity.java
+++ b/app/src/main/java/com/example/monopoly/StatsActivity.java
@@ -2,6 +2,7 @@ package com.example.monopoly;
 
 import android.os.Bundle;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.ViewModelProvider;
@@ -22,6 +23,12 @@ public class StatsActivity extends AppCompatActivity {
 
         updateStats(viewModel.players.getValue());
         viewModel.players.observe(this, this::updateStats);
+
+        viewModel.currentTurn.observe(this, player -> {
+            if (player != null) {
+                Toast.makeText(this, player.name + "'s turn", Toast.LENGTH_SHORT).show();
+            }
+        });
     }
 
     private void updateStats(List<Player> players) {

--- a/app/src/main/java/com/example/monopoly/TradeActivity.java
+++ b/app/src/main/java/com/example/monopoly/TradeActivity.java
@@ -9,6 +9,7 @@ import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.Spinner;
+import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.ViewModelProvider;
@@ -54,6 +55,12 @@ public class TradeActivity extends AppCompatActivity {
             }
             adapter.notifyDataSetChanged();
             refreshProperties(getSelectedFrom());
+        });
+
+        viewModel.currentTurn.observe(this, player -> {
+            if (player != null) {
+                Toast.makeText(this, player.name + "'s turn", Toast.LENGTH_SHORT).show();
+            }
         });
 
         fromSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {

--- a/app/src/main/java/com/example/monopoly/VisualBoardActivity.java
+++ b/app/src/main/java/com/example/monopoly/VisualBoardActivity.java
@@ -5,6 +5,7 @@ import android.text.InputType;
 import android.widget.EditText;
 import android.widget.GridLayout;
 import android.widget.ImageView;
+import android.widget.Toast;
 
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
@@ -77,6 +78,12 @@ public class VisualBoardActivity extends AppCompatActivity {
                         .setMessage(msg)
                         .setPositiveButton("OK", null)
                         .show();
+            }
+        });
+
+        viewModel.currentTurn.observe(this, player -> {
+            if (player != null) {
+                Toast.makeText(this, player.name + "'s turn", Toast.LENGTH_SHORT).show();
             }
         });
     }


### PR DESCRIPTION
## Summary
- track active player and doubles with new fields and LiveData in `GameViewModel`
- add `nextTurn` logic to handle doubles and jail after three doubles
- show toast notifications in activities when the active player's turn changes

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898ef6342d4832c9372adedbc88ec75