### PR TITLE
Implement jail handling and Get-Out-of-Jail mechanics

### DIFF
--- a/app/src/main/java/com/example/monopoly/Player.java
+++ b/app/src/main/java/com/example/monopoly/Player.java
@@ -12,6 +12,7 @@ public class Player {
     public int position;
     public int money;
     public boolean inJail;
+    public int jailTurns;
     public int jailFreeCards;
 
     public Player(String name) {
@@ -19,6 +20,7 @@ public class Player {
         this.position = 0;
         this.money = 1500;
         this.inJail = false;
+        this.jailTurns = 0;
         this.jailFreeCards = 0;
     }
 


### PR DESCRIPTION
## Summary
- Track jail status and remaining turns on each player
- Add `takeTurn` logic to handle paying fines, using cards, or rolling for doubles
- Prevent movement while jailed and initialise jail turns when sent to jail

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899577f7e98832ca998c4fd7f3b3bbc