### PR TITLE
Add interactive board tiles with animated tokens

### DIFF
--- a/app/src/main/java/com/example/monopoly/VisualBoardActivity.java
+++ b/app/src/main/java/com/example/monopoly/VisualBoardActivity.java
@@ -3,7 +3,9 @@ package com.example.monopoly;
 import android.content.Intent;
 import android.os.Bundle;
 import android.text.InputType;
+import android.view.View;
 import android.widget.EditText;
+import android.widget.FrameLayout;
 import android.widget.GridLayout;
 import android.widget.ImageView;
 import android.widget.Toast;
@@ -19,7 +21,9 @@ import java.util.Map;
 public class VisualBoardActivity extends AppCompatActivity {
     private GameViewModel viewModel;
     private GridLayout grid;
+    private FrameLayout boardContainer;
     private final Map<Integer, ImageView> playerTokens = new HashMap<>();
+    private final Map<Integer, View> tileViews = new HashMap<>();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -27,6 +31,7 @@ public class VisualBoardActivity extends AppCompatActivity {
         setContentView(R.layout.activity_visual_board);
 
         viewModel = new ViewModelProvider(this).get(GameViewModel.class);
+        boardContainer = findViewById(R.id.board_container);
         grid = findViewById(R.id.visual_board);
 
         Map<Integer, Tile> tiles = viewModel.getTileMap();
@@ -44,7 +49,10 @@ public class VisualBoardActivity extends AppCompatActivity {
             params.rowSpec = GridLayout.spec(i / 10);
             params.columnSpec = GridLayout.spec(i % 10);
             tileView.setLayoutParams(params);
+            final int index = i;
+            tileView.setOnClickListener(v -> showTileDialog(index));
             grid.addView(tileView);
+            tileViews.put(index, tileView);
         }
 
         addPlayerTokens(viewModel.players.getValue());
@@ -107,21 +115,32 @@ public class VisualBoardActivity extends AppCompatActivity {
             if (token == null) {
                 token = new ImageView(this);
                 token.setImageResource(R.drawable.icon_player);
-                grid.addView(token);
+                int size = (int) (24 * getResources().getDisplayMetrics().density);
+                FrameLayout.LayoutParams lp = new FrameLayout.LayoutParams(size, size);
+                boardContainer.addView(token, lp);
                 playerTokens.put(p.id, token);
+                final int pos = p.position;
+                boardContainer.post(() -> {
+                    View tileView = tileViews.get(pos);
+                    if (tileView != null) {
+                        token.setX(tileView.getX());
+                        token.setY(tileView.getY());
+                    }
+                });
+            } else {
+                moveToken(token, p.position);
             }
-            moveToken(token, p.position);
         }
     }
 
     private void moveToken(ImageView token, int position) {
-        GridLayout.LayoutParams params = (GridLayout.LayoutParams) token.getLayoutParams();
-        if (params == null) {
-            params = new GridLayout.LayoutParams();
+        View tileView = tileViews.get(position);
+        if (tileView == null) {
+            return;
         }
-        params.rowSpec = GridLayout.spec(position / 10);
-        params.columnSpec = GridLayout.spec(position % 10);
-        token.setLayoutParams(params);
+        float targetX = tileView.getX();
+        float targetY = tileView.getY();
+        token.animate().x(targetX).y(targetY).setDuration(300).start();
     }
 
     private void showAuctionDialog(Tile tile) {
@@ -173,5 +192,43 @@ public class VisualBoardActivity extends AppCompatActivity {
                         viewModel.buyProperty(event.player, event.tile))
                 .setNegativeButton("Cancel", (dialog, which) -> viewModel.declinePurchase(event.tile))
                 .show();
+    }
+
+    private void showTileDialog(int index) {
+        Tile tile = viewModel.getTileMap().get(index);
+        if (tile == null) {
+            return;
+        }
+        Player current = viewModel.currentTurn.getValue();
+        String ownerName = "Unowned";
+        List<Player> players = viewModel.players.getValue();
+        if (tile.isOwned && players != null) {
+            for (Player p : players) {
+                if (p.id == tile.ownerId) {
+                    ownerName = p.name;
+                    break;
+                }
+            }
+        }
+        String message = "Price: $" + tile.price + "\nOwner: " + ownerName;
+        AlertDialog.Builder builder = new AlertDialog.Builder(this)
+                .setTitle(tile.name)
+                .setMessage(message)
+                .setNegativeButton("Close", null);
+
+        boolean onCurrentTile = current != null && current.position == index;
+        if (tile.type == TileType.PROPERTY && onCurrentTile && current != null) {
+            if (!tile.isOwned) {
+                builder.setPositiveButton("Buy", (d, w) -> viewModel.buyProperty(current, tile));
+            } else if (tile.ownerId == current.id) {
+                if (tile.mortgaged) {
+                    builder.setPositiveButton("Unmortgage", (d, w) -> viewModel.unmortgageProperty(current, tile));
+                } else {
+                    builder.setPositiveButton("Mortgage", (d, w) -> viewModel.mortgageProperty(current, tile));
+                    builder.setNeutralButton("Upgrade", (d, w) -> viewModel.upgradeHouse(current.id, tile));
+                }
+            }
+        }
+        builder.show();
     }
 }

--- a/app/src/main/res/layout/activity_visual_board.xml
+++ b/app/src/main/res/layout/activity_visual_board.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<GridLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/visual_board"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/board_container"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:columnCount="10"
-    android:rowCount="10"
-    android:padding="4dp">
+    android:layout_height="match_parent">
 
-    <!-- Placeholder views for board tiles will be added dynamically -->
+    <GridLayout
+        android:id="@+id/visual_board"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:columnCount="10"
+        android:rowCount="10"
+        android:padding="4dp" />
 
-</GridLayout>
+</FrameLayout>
+


### PR DESCRIPTION
## Summary
- Make each board tile clickable and track its view for later interactions
- Overlay player tokens on the board and animate their movement between tiles
- Show property details with buy, upgrade, mortgage options when a player taps their current tile

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68998de58fb8832ca5ca558cc52ea143