### PR TITLE
Persist game state with Room

### DIFF
--- a/app/src/main/java/com/example/monopoly/GameSession.java
+++ b/app/src/main/java/com/example/monopoly/GameSession.java
@@ -1,0 +1,17 @@
+package com.example.monopoly;
+
+import androidx.room.Entity;
+import androidx.room.PrimaryKey;
+
+/**
+ * Holds global state for an in-progress game so that a session
+ * can be persisted and restored across application launches.
+ */
+@Entity
+public class GameSession {
+    @PrimaryKey
+    public int id;
+    public int currentPlayerIndex;
+    public int housesAvailable;
+    public int hotelsAvailable;
+}

--- a/app/src/main/java/com/example/monopoly/GameSessionDao.java
+++ b/app/src/main/java/com/example/monopoly/GameSessionDao.java
@@ -1,0 +1,18 @@
+package com.example.monopoly;
+
+import androidx.room.Dao;
+import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
+import androidx.room.Query;
+
+@Dao
+public interface GameSessionDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    void insert(GameSession session);
+
+    @Query("SELECT * FROM GameSession WHERE id = :id")
+    GameSession getSession(int id);
+
+    @Query("DELETE FROM GameSession")
+    void clear();
+}

--- a/app/src/main/java/com/example/monopoly/MonopolyDatabase.java
+++ b/app/src/main/java/com/example/monopoly/MonopolyDatabase.java
@@ -3,7 +3,10 @@ package com.example.monopoly;
 import androidx.room.Database;
 import androidx.room.RoomDatabase;
 
-@Database(entities = {Player.class}, version = 1)
+@Database(entities = {Player.class, TileEntity.class, Ownership.class, GameSession.class}, version = 2)
 public abstract class MonopolyDatabase extends RoomDatabase {
     public abstract PlayerDao playerDao();
+    public abstract TileDao tileDao();
+    public abstract OwnershipDao ownershipDao();
+    public abstract GameSessionDao gameSessionDao();
 }

--- a/app/src/main/java/com/example/monopoly/Ownership.java
+++ b/app/src/main/java/com/example/monopoly/Ownership.java
@@ -1,0 +1,19 @@
+package com.example.monopoly;
+
+import androidx.room.Entity;
+import androidx.room.PrimaryKey;
+
+/**
+ * Represents a relationship between a player and a tile they own.
+ * Includes dynamic information about the property such as house
+ * count and mortgage status.
+ */
+@Entity
+public class Ownership {
+    @PrimaryKey(autoGenerate = true)
+    public int id;
+    public int playerId;
+    public int tileId;
+    public int houseCount;
+    public boolean mortgaged;
+}

--- a/app/src/main/java/com/example/monopoly/OwnershipDao.java
+++ b/app/src/main/java/com/example/monopoly/OwnershipDao.java
@@ -1,0 +1,20 @@
+package com.example.monopoly;
+
+import androidx.room.Dao;
+import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
+import androidx.room.Query;
+
+import java.util.List;
+
+@Dao
+public interface OwnershipDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    void insert(Ownership ownership);
+
+    @Query("SELECT * FROM Ownership")
+    List<Ownership> getAll();
+
+    @Query("DELETE FROM Ownership")
+    void clear();
+}

--- a/app/src/main/java/com/example/monopoly/PlayerDao.java
+++ b/app/src/main/java/com/example/monopoly/PlayerDao.java
@@ -3,6 +3,7 @@ package com.example.monopoly;
 import androidx.room.Dao;
 import androidx.room.Delete;
 import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
 import androidx.room.Query;
 import androidx.room.Update;
 
@@ -10,7 +11,7 @@ import java.util.List;
 
 @Dao
 public interface PlayerDao {
-    @Insert
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
     long insertPlayer(Player player);
 
     @Update
@@ -18,6 +19,9 @@ public interface PlayerDao {
 
     @Delete
     void deletePlayer(Player player);
+
+    @Query("DELETE FROM Player")
+    void clear();
 
     @Query("SELECT * FROM Player WHERE id = :id")
     Player getPlayerById(int id);

--- a/app/src/main/java/com/example/monopoly/PropertyListActivity.java
+++ b/app/src/main/java/com/example/monopoly/PropertyListActivity.java
@@ -21,6 +21,7 @@ public class PropertyListActivity extends AppCompatActivity {
         setContentView(R.layout.activity_property_list);
 
         viewModel = new ViewModelProvider(this).get(GameViewModel.class);
+        viewModel.loadState(getApplicationContext());
         refreshProperties();
 
         viewModel.players.observe(this, players -> refreshProperties());
@@ -30,6 +31,12 @@ public class PropertyListActivity extends AppCompatActivity {
                 Toast.makeText(this, player.name + "'s turn", Toast.LENGTH_SHORT).show();
             }
         });
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        viewModel.saveState(getApplicationContext());
     }
 
     private void refreshProperties() {

--- a/app/src/main/java/com/example/monopoly/StatsActivity.java
+++ b/app/src/main/java/com/example/monopoly/StatsActivity.java
@@ -19,6 +19,7 @@ public class StatsActivity extends AppCompatActivity {
         setContentView(R.layout.activity_stats);
 
         viewModel = new ViewModelProvider(this).get(GameViewModel.class);
+        viewModel.loadState(getApplicationContext());
         statsText = findViewById(R.id.stats_text);
 
         updateStats(viewModel.players.getValue());
@@ -29,6 +30,12 @@ public class StatsActivity extends AppCompatActivity {
                 Toast.makeText(this, player.name + "'s turn", Toast.LENGTH_SHORT).show();
             }
         });
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        viewModel.saveState(getApplicationContext());
     }
 
     private void updateStats(List<Player> players) {

--- a/app/src/main/java/com/example/monopoly/TileDao.java
+++ b/app/src/main/java/com/example/monopoly/TileDao.java
@@ -1,0 +1,20 @@
+package com.example.monopoly;
+
+import androidx.room.Dao;
+import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
+import androidx.room.Query;
+
+import java.util.List;
+
+@Dao
+public interface TileDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    void insertAll(List<TileEntity> tiles);
+
+    @Query("SELECT * FROM TileEntity")
+    List<TileEntity> getAll();
+
+    @Query("SELECT COUNT(*) FROM TileEntity")
+    int count();
+}

--- a/app/src/main/java/com/example/monopoly/TileEntity.java
+++ b/app/src/main/java/com/example/monopoly/TileEntity.java
@@ -1,0 +1,19 @@
+package com.example.monopoly;
+
+import androidx.room.Entity;
+import androidx.room.PrimaryKey;
+
+/**
+ * Room representation of a board tile. Only stores immutable
+ * information about the tile so that the static board can be
+ * reconstructed or queried from the database if needed.
+ */
+@Entity
+public class TileEntity {
+    @PrimaryKey
+    public int id;
+    public String name;
+    public String type;
+    public int price;
+    public String colorGroup;
+}

--- a/app/src/main/java/com/example/monopoly/TradeActivity.java
+++ b/app/src/main/java/com/example/monopoly/TradeActivity.java
@@ -31,6 +31,7 @@ public class TradeActivity extends AppCompatActivity {
         setContentView(R.layout.activity_trade);
 
         viewModel = new ViewModelProvider(this).get(GameViewModel.class);
+        viewModel.loadState(getApplicationContext());
 
         fromSpinner = findViewById(R.id.spinner_from);
         toSpinner = findViewById(R.id.spinner_to);
@@ -100,6 +101,12 @@ public class TradeActivity extends AppCompatActivity {
         });
 
         refreshProperties(getSelectedFrom());
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        viewModel.saveState(getApplicationContext());
     }
 
     private Player getSelectedFrom() {

--- a/app/src/main/java/com/example/monopoly/VisualBoardActivity.java
+++ b/app/src/main/java/com/example/monopoly/VisualBoardActivity.java
@@ -31,6 +31,7 @@ public class VisualBoardActivity extends AppCompatActivity {
         setContentView(R.layout.activity_visual_board);
 
         viewModel = new ViewModelProvider(this).get(GameViewModel.class);
+        viewModel.loadState(getApplicationContext());
         boardContainer = findViewById(R.id.board_container);
         grid = findViewById(R.id.visual_board);
 
@@ -104,6 +105,12 @@ public class VisualBoardActivity extends AppCompatActivity {
                 finish();
             }
         });
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        viewModel.saveState(getApplicationContext());
     }
 
     private void addPlayerTokens(List<Player> players) {


### PR DESCRIPTION
## Summary
- Expand MonopolyDatabase with Tile, Ownership, and GameSession tables and DAOs
- Add Room-backed load/save logic in GameViewModel to persist game sessions
- Have Activities reload ViewModel state on launch and persist on pause

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689990553234832cb5b0b70c55f4b69d